### PR TITLE
handle useradd(8) and adduser(8)

### DIFF
--- a/sysclean.pl
+++ b/sysclean.pl
@@ -143,6 +143,7 @@ sub add_expected_base
 		'/bsd.rd' => 1,
 		'/bsd.sp' => 1,
 		'/obsd' => 1,
+		'/etc/adduser.conf' => 1,
 		'/etc/fstab' => 1,
 		'/etc/hosts' => 1,
 		'/etc/iked/local.pub' => 1,
@@ -160,6 +161,7 @@ sub add_expected_base
 		'/etc/myname' => 1,
 		'/etc/pkg.conf' => 1,
 		'/etc/random.seed' => 1,
+		'/etc/usermgmt.conf' => 1,
 	};
 
 	# additionnal expected files, using pattern


### PR DESCRIPTION
The tools will automatically create a configuration file if it does not exist.
Considering useradd(8) run by pkg_add to handle users it will likely be present
in most installations. While adduser(8) will only be explicitely run by the
admin, let's be consistent; so let's add both config files to add_expected_base.
