### PR TITLE
Relax defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,8 @@ The options are as follows:
 > '+'
 > is skipped at the beginning of a line.
 
-> Some files are implictly included:
-
-> > @include "/etc/changelist"
-> > @include "/etc/sysmerge.ignore"
+> */etc/changelist*
+> is implictly included.
 
 # EXAMPLES
 
@@ -123,4 +121,4 @@ in 2016.
 was written by
 Sebastien Marie &lt;[semarie@online.fr](mailto:semarie@online.fr)&gt;.
 
-OpenBSD 6.1 - June 15, 2017
+OpenBSD 6.1 - June 16, 2017

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ The options are as follows:
 > file format, the character
 > '+'
 > is skipped at the beginning of a line.
-> Additional files can be included with the
-> **@include**
-> keyword, for example:
+
+> Some files are implictly included:
 
 > > @include "/etc/changelist"
+> > @include "/etc/sysmerge.ignore"
 
 # EXAMPLES
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SYSCLEAN(8) - System Manager's Manual
 # SYNOPSIS
 
 **sysclean**
-\[**-s**&nbsp;|&nbsp;**-f**&nbsp;|&nbsp;**-a**&nbsp;|&nbsp;**-p**]
+\[**-f**&nbsp;|&nbsp;**-a**&nbsp;|&nbsp;**-p**]
 \[**-i**]
 
 # DESCRIPTION
@@ -27,16 +27,6 @@ It only reports obsolete filenames or packages using out-of-date libraries.
 
 The options are as follows:
 
-**-s**
-
-> Safe mode.
-> **sysclean**
-> lists obsolete filenames on the system.
-> It excludes any dynamic libraries and all files under the
-> */etc*
-> directory.
-> This is the default mode.
-
 **-f**
 
 > File mode.
@@ -45,6 +35,7 @@ The options are as follows:
 > */etc*
 > will be inspected.
 > It will report base libraries with versions newer than what's expected.
+> This is the default mode.
 
 **-a**
 
@@ -136,4 +127,4 @@ in 2016.
 was written by
 Sebastien Marie &lt;[semarie@online.fr](mailto:semarie@online.fr)&gt;.
 
-OpenBSD 6.1 - March 29, 2017
+OpenBSD 6.1 - June 15, 2017

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SYSCLEAN(8) - System Manager's Manual
 # SYNOPSIS
 
 **sysclean**
-\[**-f**&nbsp;|&nbsp;**-a**&nbsp;|&nbsp;**-p**]
+\[**-a**&nbsp;|&nbsp;**-p**]
 \[**-i**]
 
 # DESCRIPTION
@@ -25,17 +25,13 @@ taking files from both the base system and packages into account.
 does not remove any files on the system.
 It only reports obsolete filenames or packages using out-of-date libraries.
 
+By default,
+**sysclean**
+lists obsolete filenames on the system.
+It excludes any used dynamic libraries.
+It will report base libraries with versions newer than what's expected.
+
 The options are as follows:
-
-**-f**
-
-> File mode.
-> **sysclean**
-> will additionally show old libraries that aren't used by any packages, and
-> */etc*
-> will be inspected.
-> It will report base libraries with versions newer than what's expected.
-> This is the default mode.
 
 **-a**
 
@@ -91,7 +87,7 @@ The options are as follows:
 
 Obtain a list of outdated files (without libraries used by packages):
 
-	# sysclean -f
+	# sysclean
 	/usr/lib/libc.so.83.0
 
 Obtain a list of old libraries and the package using them:

--- a/sysclean.8
+++ b/sysclean.8
@@ -83,11 +83,11 @@ For compatibility with the
 file format, the character
 .Sq +
 is skipped at the beginning of a line.
-Additional files can be included with the
-.Ic @include
-keyword, for example:
+.Pp
+Some files are implictly included:
 .Bd -literal -offset indent
 @include "/etc/changelist"
+@include "/etc/sysmerge.ignore"
 .Ed
 .El
 .Sh EXAMPLES

--- a/sysclean.8
+++ b/sysclean.8
@@ -84,11 +84,8 @@ file format, the character
 .Sq +
 is skipped at the beginning of a line.
 .Pp
-Some files are implictly included:
-.Bd -literal -offset indent
-@include "/etc/changelist"
-@include "/etc/sysmerge.ignore"
-.Ed
+.Pa /etc/changelist
+is implictly included.
 .El
 .Sh EXAMPLES
 Obtain a list of outdated files (without libraries used by packages):

--- a/sysclean.8
+++ b/sysclean.8
@@ -22,7 +22,7 @@
 .Nd list obsolete files between OpenBSD upgrades
 .Sh SYNOPSIS
 .Nm
-.Op Fl f | a | p
+.Op Fl a | p
 .Op Fl i
 .Sh DESCRIPTION
 .Nm
@@ -38,16 +38,14 @@ taking files from both the base system and packages into account.
 does not remove any files on the system.
 It only reports obsolete filenames or packages using out-of-date libraries.
 .Pp
+By default,
+.Nm
+lists obsolete filenames on the system.
+It excludes any used dynamic libraries.
+It will report base libraries with versions newer than what's expected.
+.Pp
 The options are as follows:
 .Bl -tag -width Ds
-.It Fl f
-File mode.
-.Nm
-will additionally show old libraries that aren't used by any packages, and
-.Pa /etc
-will be inspected.
-It will report base libraries with versions newer than what's expected.
-This is the default mode.
 .It Fl a
 All files mode.
 .Nm
@@ -95,7 +93,7 @@ keyword, for example:
 .Sh EXAMPLES
 Obtain a list of outdated files (without libraries used by packages):
 .Bd -literal -offset indent
-# sysclean -f
+# sysclean
 /usr/lib/libc.so.83.0
 .Ed
 .Pp

--- a/sysclean.8
+++ b/sysclean.8
@@ -22,7 +22,7 @@
 .Nd list obsolete files between OpenBSD upgrades
 .Sh SYNOPSIS
 .Nm
-.Op Fl s | f | a | p
+.Op Fl f | a | p
 .Op Fl i
 .Sh DESCRIPTION
 .Nm
@@ -40,14 +40,6 @@ It only reports obsolete filenames or packages using out-of-date libraries.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
-.It Fl s
-Safe mode.
-.Nm
-lists obsolete filenames on the system.
-It excludes any dynamic libraries and all files under the
-.Pa /etc
-directory.
-This is the default mode.
 .It Fl f
 File mode.
 .Nm
@@ -55,6 +47,7 @@ will additionally show old libraries that aren't used by any packages, and
 .Pa /etc
 will be inspected.
 It will report base libraries with versions newer than what's expected.
+This is the default mode.
 .It Fl a
 All files mode.
 .Nm

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -26,10 +26,9 @@ package sysclean;
 sub subclass
 {
 	my ($self, $options) = @_;
-	return 'sysclean::files'    if (defined $$options{f});
 	return 'sysclean::allfiles' if (defined $$options{a});
 	return 'sysclean::packages' if (defined $$options{p});
-	return 'sysclean::safefiles';
+	return 'sysclean::files';
 }
 
 # choose class for mode, depending on %options
@@ -40,7 +39,6 @@ sub create
 	my $with_ignored = !defined $$options{i};
 	my $mode_count = 0;
 
-	$mode_count++ if (defined $$options{s});
 	$mode_count++ if (defined $$options{f});
 	$mode_count++ if (defined $$options{a});
 	$mode_count++ if (defined $$options{p});
@@ -70,7 +68,7 @@ sub new
 # print usage and exit
 sub usage
 {
-	print "usage: $0 [ -s | -f | -a | -p ] [-i]\n";
+	print "usage: $0 [ -f | -a | -p ] [-i]\n";
 	exit 1
 }
 
@@ -345,39 +343,6 @@ sub find_sub
 	print($filename, "\n");
 }
 
-package sysclean::safefiles;
-use parent -norequire, qw(sysclean);
-
-sub init_ignored
-{
-	my $self = shift;
-
-	$self->SUPER::init_ignored();
-
-	$self->{ignored}{'/etc'} = 1;
-}
-
-sub plist_reader
-{
-	return sub {
-	    my ($fh, $cont) = @_;
-	    while (<$fh>) {
-		    next unless m/^\@(?:cwd|name|info|man|file|lib|shell|extra|sample|bin)\b/o || !m/^\@/o;
-		    &$cont($_);
-	    };
-	}
-}
-
-sub find_sub
-{
-	my ($self, $filename) = @_;
-
-	# skip all libraries
-	return if ($filename =~ m|/lib[^/]+\.so[^/]*$|o);
-
-	print($filename, "\n");
-}
-
 package sysclean::files;
 use parent -norequire, qw(sysclean);
 
@@ -501,7 +466,7 @@ use Getopt::Std;
 
 my %options = ();	# program flags
 
-getopts("sfapih", \%options) || sysclean->usage;
+getopts("fapih", \%options) || sysclean->usage;
 sysclean->usage if (defined $options{h} || scalar(@ARGV) != 0);
 
 sysclean->err(1, "need root privileges") if ($> != 0);

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -118,6 +118,11 @@ sub init_ignored
 		'/var/www/run' => 1,
 		'/var/www/tmp' => 1,
 	};
+
+	# additionnal ignored files, using pattern
+	foreach my $filename (</bsd.syspatch*>) {
+		$self->{ignored}{$filename} = 1;
+	}
 }
 
 sub init

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -60,6 +60,7 @@ sub new
 	if ($with_ignored) {
 		$self->add_user_ignored("/etc/changelist");
 		$self->add_user_ignored("/etc/sysclean.ignore");
+		$self->{expected}{'/etc/sysclean.ignore'} = 1;
 	}
 
 	return $self;

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -59,6 +59,7 @@ sub new
 	$self->init;
 	if ($with_ignored) {
 		$self->add_user_ignored("/etc/changelist");
+		$self->add_user_ignored("/etc/sysmerge.ignore");
 		$self->add_user_ignored("/etc/sysclean.ignore");
 		$self->{expected}{'/etc/sysclean.ignore'} = 1;
 	}

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -458,6 +458,6 @@ my %options = ();	# program flags
 getopts("sfapih", \%options) || sysclean->usage;
 sysclean->usage if (defined $options{h} || scalar(@ARGV) != 0);
 
-sysclean->warn("need root privileges for complete listing") if ($> != 0);
+sysclean->err(1, "need root privileges") if ($> != 0);
 
 sysclean->create(\%options)->walk;

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -39,7 +39,6 @@ sub create
 	my $with_ignored = !defined $$options{i};
 	my $mode_count = 0;
 
-	$mode_count++ if (defined $$options{f});
 	$mode_count++ if (defined $$options{a});
 	$mode_count++ if (defined $$options{p});
 	sysclean->usage if ($mode_count > 1);
@@ -68,7 +67,7 @@ sub new
 # print usage and exit
 sub usage
 {
-	print "usage: $0 [ -f | -a | -p ] [-i]\n";
+	print "usage: $0 [ -a | -p ] [-i]\n";
 	exit 1
 }
 
@@ -466,7 +465,7 @@ use Getopt::Std;
 
 my %options = ();	# program flags
 
-getopts("fapih", \%options) || sysclean->usage;
+getopts("apih", \%options) || sysclean->usage;
 sysclean->usage if (defined $options{h} || scalar(@ARGV) != 0);
 
 sysclean->err(1, "need root privileges") if ($> != 0);

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -112,6 +112,7 @@ sub init_ignored
 		'/var/run' => 1,
 		'/var/spool/smtpd' => 1,
 		'/var/sysmerge' => 1,
+		'/var/syspatch' => 1,
                 '/var/www/htdocs' => 1,
 		'/var/www/logs' => 1,
 		'/var/www/run' => 1,

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -56,7 +56,6 @@ sub new
 	$self->init;
 	if ($with_ignored) {
 		$self->add_user_ignored("/etc/changelist");
-		$self->add_user_ignored("/etc/sysmerge.ignore");
 		$self->add_user_ignored("/etc/sysclean.ignore");
 		$self->{expected}{'/etc/sysclean.ignore'} = 1;
 	}

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -100,6 +100,7 @@ sub init_ignored
 		'/usr/local' => 1, # remove ?
 		'/usr/obj' => 1,
 		'/usr/ports' => 1,
+		'/usr/share/compile' => 1,
 		'/usr/src' => 1,
 		'/usr/xenocara' => 1,
                 '/usr/xobj' => 1,

--- a/sysclean.pl
+++ b/sysclean.pl
@@ -57,7 +57,10 @@ sub new
 
 	$self->init_ignored;
 	$self->init;
-	$self->add_user_ignored("/etc/sysclean.ignore") if ($with_ignored);
+	if ($with_ignored) {
+		$self->add_user_ignored("/etc/changelist");
+		$self->add_user_ignored("/etc/sysclean.ignore");
+	}
 
 	return $self;
 }


### PR DESCRIPTION
In order to implement ignoring files that are not part of a standard installation, several changes on sysclean.

- simplification on possible options: only `sysclean [-a | -p] [-i]`
- add more magic to default mode: use `rcctl ls on` to conditionally adds expected/ignored files based on enabled daemon and services
- make `/etc/changelog` and `/etc/sysmerge.ignore` files to be implictly included by `/etc/sysclean.ignore`
- ignore `/etc/sysclean.ignore` by default, as now we don't strictly target a standard installation
- add `/usr/share/compile` (KARL) to ignored list: it could be created by rc(8) at startup
- includes #6 about syspatch(8) and enhance it to manage kernels too