### PR TITLE
add -z option for NUL delimited output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SYSCLEAN(8) - System Manager's Manual
 
 **sysclean**
 \[**-a**&nbsp;|&nbsp;**-p**]
-\[**-i**]
+\[**-iz**]
 
 # DESCRIPTION
 
@@ -53,6 +53,12 @@ The options are as follows:
 > Package mode.
 > **sysclean**
 > will output package names that are using obsolete files.
+
+**-z**
+
+> NUL output mode.
+> **sysclean**
+> will output filenames or package names separated by NUL rather than newline.
 
 # ENVIRONMENT
 
@@ -123,4 +129,4 @@ in 2016.
 was written by
 Sebastien Marie &lt;[semarie@online.fr](mailto:semarie@online.fr)&gt;.
 
-OpenBSD 6.3 - July 14, 2018
+OpenBSD 7.1 - April 28, 2022

--- a/sysclean.8
+++ b/sysclean.8
@@ -14,7 +14,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd Jul 14, 2018
+.Dd April 28, 2022
 .Dt SYSCLEAN 8
 .Os
 .Sh NAME
@@ -23,7 +23,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl a | p
-.Op Fl i
+.Op Fl iz
 .Sh DESCRIPTION
 .Nm
 is a
@@ -61,6 +61,10 @@ will include filenames that are ignored by default, using
 Package mode.
 .Nm
 will output package names that are using obsolete files.
+.It Fl z
+NUL output mode.
+.Nm
+will output filenames or package names separated by NUL rather than newline.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width "PKG_DBDIR"


### PR DESCRIPTION
It would be nice to be able to pipe into `xargs -0` because `xargs` parsing without `-0` is interesting to say the least. I don't do much perl, but it runs correctly.