### PR TITLE
add new users and groups mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SYSCLEAN(8) - System Manager's Manual
 # SYNOPSIS
 
 **sysclean**
-\[**-a**&nbsp;|&nbsp;**-p**]
+\[**-a**&nbsp;|&nbsp;**-g**&nbsp;|&nbsp;**-p**&nbsp;|&nbsp;**-u**]
 \[**-i**]
 
 # DESCRIPTION
@@ -41,6 +41,12 @@ The options are as follows:
 > **sysclean**
 > will not exclude filenames used by installed packages from output.
 
+**-g**
+
+> Group mode.
+> **sysclean**
+> will list obsolete system groups.
+
 **-i**
 
 > With ignored.
@@ -53,6 +59,12 @@ The options are as follows:
 > Package mode.
 > **sysclean**
 > will output package names that are using obsolete files.
+
+**-u**
+
+> User mode.
+> **sysclean**
+> will list obsolete system users.
 
 # ENVIRONMENT
 
@@ -123,4 +135,4 @@ in 2016.
 was written by
 Sebastien Marie &lt;[semarie@online.fr](mailto:semarie@online.fr)&gt;.
 
-OpenBSD 6.3 - July 14, 2018
+OpenBSD 7.2 - December 19, 2022

--- a/sysclean.8
+++ b/sysclean.8
@@ -14,7 +14,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd Jul 14, 2018
+.Dd December 19, 2022
 .Dt SYSCLEAN 8
 .Os
 .Sh NAME
@@ -22,7 +22,7 @@
 .Nd list obsolete files between OpenBSD upgrades
 .Sh SYNOPSIS
 .Nm
-.Op Fl a | p
+.Op Fl a | g | p | u
 .Op Fl i
 .Sh DESCRIPTION
 .Nm
@@ -52,6 +52,10 @@ The options are as follows:
 All files mode.
 .Nm
 will not exclude filenames used by installed packages from output.
+.It Fl g
+Group mode.
+.Nm
+will list obsolete system groups.
 .It Fl i
 With ignored.
 .Nm
@@ -61,6 +65,10 @@ will include filenames that are ignored by default, using
 Package mode.
 .Nm
 will output package names that are using obsolete files.
+.It Fl u
+User mode.
+.Nm
+will list obsolete system users.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width "PKG_DBDIR"


### PR DESCRIPTION
Sometimes UIDs/GIDs get reused; if a user missed the upgrade note to remove the user or group, a future sysmerge will fail causing sometimes non-obvious issues. (A recent example, the _agentx group reused the GID for _rtadvd, and a missing _agentx group causes vmd to fail to start.)

This adds a new mode to find users and groups in the system range (< 1000) and unused by base or ports. I'm not set on the colon to distinguish groups from users and have no strong preference on one mode for users and groups or one mode for each.

I don't write much perl, so apologies if the style is atrocious.